### PR TITLE
Simplified remove_empty

### DIFF
--- a/mws/mws.py
+++ b/mws/mws.py
@@ -78,10 +78,7 @@ def remove_empty(d):
     Return:
         dict
     """
-    for key in set(d.keys()):
-        if not d[key]:
-            del d[key]
-    return d
+    return {k: v for k, v in d.items() if not v}
 
 
 def remove_namespace(xml):

--- a/mws/mws.py
+++ b/mws/mws.py
@@ -78,7 +78,7 @@ def remove_empty(d):
     Return:
         dict
     """
-    return {k: v for k, v in d.items() if not v}
+    return {k: v for k, v in d.items() if v}
 
 
 def remove_namespace(xml):


### PR DESCRIPTION
Instead of mutating a dict building a new one is better. Should be faster than using del and safe. Also casting a set of dict.keys is not necessary, keys in a dict are always unique.